### PR TITLE
Fix a byte-compile warning

### DIFF
--- a/twitch-api.el
+++ b/twitch-api.el
@@ -263,7 +263,7 @@ If LIMIT is an integer, pass that along to `twitch-api'."
         [("Streamer" 17 t) ("Viewers" 7 twitch-api--sort-by-viewers)
          ("Game" 20 t) ("Status" 0 nil)])
   (setq tabulated-list-sort-key (cons "Viewers" nil))
-  (add-hook #'tabulated-list-revert-hook
+  (add-hook 'tabulated-list-revert-hook
             'twitch-api--refresh-top-streams nil t))
 
 (defun twitch-api--refresh-top-streams ()


### PR DESCRIPTION
tabulated-list-revert-hook is a variable, not a function

```
twitch-api.el:266:15: Warning: the function ‘tabulated-list-revert-hook’ is
    not known to be defined.
```